### PR TITLE
Ignore invalid property values

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -40,7 +40,10 @@ class EditorConfig(sublime_plugin.EventListener):
 			#window.run_command('expand_tabs', {'set_translate_tabs': True})
 		# Indent size
 		if indent_size:
-			settings.set('tab_size', int(indent_size))
+			try:
+				settings.set('tab_size', int(indent_size))
+			except ValueError:
+				pass
 		# EOL
 		if end_of_line in LINE_ENDINGS:
 			view.set_line_endings(LINE_ENDINGS[end_of_line])


### PR DESCRIPTION
This change is in accordance with the suggestion on the [Plugin How To](https://github.com/editorconfig/editorconfig/wiki/Plugin-How-To) that invalid property values should be ignored.

Among other features, this allows for code bases with quarantined messy file directories to be left alone when no sane EditorConfig value can be specified and the text editor should be left to figure out what's best.  For example:

```
[*.js]
indent_style = tab
end_of_line = lf

[messy_libraries_we_use/**.js]
indent_style = N/A
end_of_line = N/A
```
