### PR TITLE
Enforce settings for newly created -> saved files

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -25,19 +25,24 @@ CHARSETS = {
 }
 
 class EditorConfig(sublime_plugin.EventListener):
+	MARKER = 'editorconfig'
+
 	def on_activated(self, view):
-		if view.settings().has('editorconfig'):
-			return
-		self.init(view, False)
-		view.settings().set('editorconfig', True)
+		if not view.settings().has(self.MARKER):
+			self.init(view, False)
 
 	def on_pre_save(self, view):
 		self.init(view, True)
+
+	def on_post_save(self, view):
+		if not view.settings().has(self.MARKER):
+			self.init(view, False)
 
 	def init(self, view, pre_save):
 		path = view.file_name()
 		if not path:
 			return
+
 		try:
 			config = get_properties(path)
 		except EditorConfigError:
@@ -80,3 +85,5 @@ class EditorConfig(sublime_plugin.EventListener):
 			settings.set('ensure_newline_at_eof_on_save', True)
 		elif insert_final_newline == 'false':
 			settings.set('ensure_newline_at_eof_on_save', False)
+
+		view.settings().set(self.MARKER, True)


### PR DESCRIPTION
When users create a new file, it doesn't have a name yet so the plugin doesn't know which settings it should apply. Later, when users save the new file and assign a name to it, they expect the plugin to apply the settings from their `.editorconfig` file according to the new file name and it doesn't happen so they have to close the file and open it again. Very annoying. This PR fixes the problem by applying the settings via `on_post_save` hook. To make sure we don't do that for every save operation (as it might lead to performance degradation), we mark the files and skip them later.
