### PR TITLE
Apply config for already opened files

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -25,8 +25,11 @@ CHARSETS = {
 }
 
 class EditorConfig(sublime_plugin.EventListener):
-	def on_load(self, view):
+	def on_activated(self, view):
+		if view.settings().has('editorconfig'):
+			return
 		self.init(view, False)
+		view.settings().set('editorconfig', True)
 
 	def on_pre_save(self, view):
 		self.init(view, True)


### PR DESCRIPTION
When editor is not opened and you open a file, config does not apply, because plugin is loaded after file has been opened. Therefore on_load method will never be called for this file.
