### PR TITLE
Removed unnecessary `import re` stmt from EditorConfig.py

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -2,7 +2,6 @@ import pprint
 import sublime_plugin
 
 def unexpanduser(path):
-	import re
 	from os.path import expanduser
 	return path.replace(expanduser('~'), '~')
 


### PR DESCRIPTION
No need to `import re` module in `unexpanduser(str)` function due to commit 460dbd101b12e0eb4c022128e19029ab7c51ed93.
