### PR TITLE
Force whitespace pre-save

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -1,4 +1,5 @@
 import pprint
+import sublime
 import sublime_plugin
 
 def unexpanduser(path):
@@ -70,6 +71,7 @@ class EditorConfig(sublime_plugin.EventListener):
 		charset = config.get('charset')
 		end_of_line = config.get('end_of_line')
 		indent_style = config.get('indent_style')
+		position = view.viewport_position()
 		if charset in CHARSETS:
 			view.set_encoding(CHARSETS[charset])
 		if end_of_line in LINE_ENDINGS:
@@ -78,6 +80,7 @@ class EditorConfig(sublime_plugin.EventListener):
 			view.run_command('expand_tabs', {'set_translate_tabs': True})
 		elif indent_style == 'tab':
 			view.run_command('unexpand_tabs', {'set_translate_tabs': True})
+			view.set_viewport_position(position, False)
 
 	def apply_config(self, view, config):
 		settings = view.settings()

--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -74,9 +74,9 @@ class EditorConfig(sublime_plugin.EventListener):
 			view.set_encoding(CHARSETS[charset])
 		if end_of_line in LINE_ENDINGS:
 			view.set_line_endings(LINE_ENDINGS[end_of_line])
-		if indent_style == 'space' and spaces == False:
+		if indent_style == 'space':
 			view.run_command('expand_tabs', {'set_translate_tabs': True})
-		elif indent_style == 'tab' and spaces == True:
+		elif indent_style == 'tab':
 			view.run_command('unexpand_tabs', {'set_translate_tabs': True})
 
 	def apply_config(self, view, config):

--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -80,7 +80,7 @@ class EditorConfig(sublime_plugin.EventListener):
 			view.run_command('expand_tabs', {'set_translate_tabs': True})
 		elif indent_style == 'tab':
 			view.run_command('unexpand_tabs', {'set_translate_tabs': True})
-			view.set_viewport_position(position, False)
+			view.set_viewport_position(position)
 
 	def apply_config(self, view, config):
 		settings = view.settings()


### PR DESCRIPTION
Removing the `spaces == True` and `spaces == False` check in the `apply_pre_save` method simply tells Sublime to enforce the tabs/spaces style throughout the document on save, as requested in #33