### PR TITLE
Add a snippet for EditorConfig file content

### DIFF
--- a/editorconfig.sublime-snippet
+++ b/editorconfig.sublime-snippet
@@ -3,12 +3,12 @@
 root = true
 
 [*]
-indent_style = ${1:tab}
+${1/(^$)|.*/?1:# tab | space\n/i}indent_style = ${1:tab}${1/(t$)|(s$)|(ta$)|(sp$)|.*/?1:ab:?2:pace:?3:b:?4:ace/i}
 #indent_size = ${2:4}
-end_of_line = ${3:lf}
-charset = ${4:utf-8}
-trim_trailing_whitespace = ${5:true}
-insert_final_newline = ${6:true}
+${3/(^$)|.*/?1:# lf | cr\n/i}end_of_line = ${3:lf}${3/(l$)|(c$)|.*/?1:f:?2:r/i}
+${4/(^$)|.*/?1:# latin1 | utf-8 | utf-8-bom | utf-16be | utf-16le\n/i}charset = ${4:utf-8}${4/(l$)|(u$)|(la$)|(ut$)|.*/(?1:atin1:)(?2:tf-8:)(?3:tin1:)(?4:f-8)/i}
+${5/(^$)|.*/?1:# true | false\n/i}trim_trailing_whitespace = ${5:true}${5/(t$)|(f$)|(tr$)|(fa$)|.*/?1:rue:?2:alse:?3:ue:?4:lse/i}
+${6/(^$)|.*/?1:# true | false\n/i}insert_final_newline = ${6:true}${6/(t$)|(f$)|(tr$)|(fa$)|.*/?1:rue:?2:alse:?3:ue:?4:lse/i}
 
 [*.md]
 trim_trailing_whitespace = false

--- a/editorconfig.sublime-snippet
+++ b/editorconfig.sublime-snippet
@@ -1,14 +1,18 @@
 <snippet>
 	<content><![CDATA[
+# EditorConfig is awesome: http://EditorConfig.org
 root = ${1:true}
 
 [*]
-charset = ${2:utf-8}
-end_of_line = ${3:lf}
-indent_size = ${4:4}
-indent_style = ${5:space}
-insert_final_newline = ${6:true}
-trim_trailing_whitespace = ${7:true}
+indent_style = ${2:tab}
+#indent_size = ${3:4}
+end_of_line = ${4:lf}
+charset = ${5:utf-8}
+trim_trailing_whitespace = ${6:true}
+insert_final_newline = ${7:true}
+
+[*.md]
+trim_trailing_whitespace = ${8:false}
 ]]></content>
 	<tabTrigger>editorconfig</tabTrigger>
 </snippet>

--- a/editorconfig.sublime-snippet
+++ b/editorconfig.sublime-snippet
@@ -1,18 +1,17 @@
 <snippet>
 	<content><![CDATA[
-# EditorConfig is awesome: http://EditorConfig.org
-root = ${1:true}
+root = true
 
 [*]
-indent_style = ${2:tab}
-#indent_size = ${3:4}
-end_of_line = ${4:lf}
-charset = ${5:utf-8}
-trim_trailing_whitespace = ${6:true}
-insert_final_newline = ${7:true}
+indent_style = ${1:tab}
+#indent_size = ${2:4}
+end_of_line = ${3:lf}
+charset = ${4:utf-8}
+trim_trailing_whitespace = ${5:true}
+insert_final_newline = ${6:true}
 
 [*.md]
-trim_trailing_whitespace = ${8:false}
+trim_trailing_whitespace = false
 ]]></content>
 	<tabTrigger>editorconfig</tabTrigger>
 </snippet>

--- a/editorconfig.sublime-snippet
+++ b/editorconfig.sublime-snippet
@@ -11,4 +11,5 @@ ${5/(^$)|.*/?1:# true | false\n/i}trim_trailing_whitespace = ${5:true}${5/(t$)|(
 ${6/(^$)|.*/?1:# true | false\n/i}insert_final_newline = ${6:true}${6/(t$)|(f$)|(tr$)|(fa$)|.*/?1:rue:?2:alse:?3:ue:?4:lse/i}
 ]]></content>
 	<tabTrigger>editorconfig</tabTrigger>
+	<scope>source.ini.editorconfig,text.plain</scope>
 </snippet>

--- a/editorconfig.sublime-snippet
+++ b/editorconfig.sublime-snippet
@@ -1,0 +1,14 @@
+<snippet>
+	<content><![CDATA[
+root = ${1:true}
+
+[*]
+charset = ${2:utf-8}
+end_of_line = ${3:lf}
+indent_size = ${4:4}
+indent_style = ${5:space}
+insert_final_newline = ${6:true}
+trim_trailing_whitespace = ${7:true}
+]]></content>
+	<tabTrigger>editorconfig</tabTrigger>
+</snippet>

--- a/editorconfig.sublime-snippet
+++ b/editorconfig.sublime-snippet
@@ -4,14 +4,11 @@ root = true
 
 [*]
 ${1/(^$)|.*/?1:# tab | space\n/i}indent_style = ${1:tab}${1/(t$)|(s$)|(ta$)|(sp$)|.*/?1:ab:?2:pace:?3:b:?4:ace/i}
-#indent_size = ${2:4}
-${3/(^$)|.*/?1:# lf | cr\n/i}end_of_line = ${3:lf}${3/(l$)|(c$)|.*/?1:f:?2:r/i}
+${2/(^$)|.*/?1:# /}indent_size = ${2:}
+${3/(^$)|.*/?1:# lf | crlf\n/i}end_of_line = ${3:lf}${3/(l$)|(c$)|.*/?1:f:?2:rlf/i}
 ${4/(^$)|.*/?1:# latin1 | utf-8 | utf-8-bom | utf-16be | utf-16le\n/i}charset = ${4:utf-8}${4/(l$)|(u$)|(la$)|(ut$)|.*/(?1:atin1:)(?2:tf-8:)(?3:tin1:)(?4:f-8)/i}
 ${5/(^$)|.*/?1:# true | false\n/i}trim_trailing_whitespace = ${5:true}${5/(t$)|(f$)|(tr$)|(fa$)|.*/?1:rue:?2:alse:?3:ue:?4:lse/i}
 ${6/(^$)|.*/?1:# true | false\n/i}insert_final_newline = ${6:true}${6/(t$)|(f$)|(tr$)|(fa$)|.*/?1:rue:?2:alse:?3:ue:?4:lse/i}
-
-[*.md]
-trim_trailing_whitespace = false
 ]]></content>
 	<tabTrigger>editorconfig</tabTrigger>
 </snippet>

--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,9 @@ trim_trailing_whitespace = false
 
 If you can't remember all settings managed by the EditorConfig file, you'll love the `editorconfig` snippet.
 
-Just type `editorconfig` + `tab`, and your editor will focus on the first setting's value (root = *true*). You can change the value, if you want, and jump to the next setting's value by hitting `tab` and so on.
+Just type `editorconfig` + <kbd>tab</kbd>, and your editor will focus on the first setting's value (root = *true*). You can change the value, if you want, and jump to the next setting's value by hitting <kbd>tab</kbd> and so on.
 
-You can be in a context where `editorconfig` + `tab` trigger another snippet. In that case, simply use `Goto anywhere` (`Ctrl` + `P` on Linux/Windows or `⌘` + `P` on OSX), type `editorconfig`, select `Snippet: editorconfig` and hit `Enter`.
+You can be in a context where `editorconfig` + <kbd>tab</kbd> trigger another snippet. In that case, simply use `Goto anywhere` (<kbd>Ctrl</kbd> + <kbd>P</kbd> on Linux/Windows or <kbd>⌘</kbd> + <kbd>P</kbd> on OSX), type `editorconfig`, select `Snippet: editorconfig` and hit <kbd>Enter</kbd>.
 
 ### View active config
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ trim_trailing_whitespace = false
 
 If you can't remember all settings managed by the EditorConfig file, you'll love the `editorconfig` snippet.
 
-Just type `editorconfig` + <kbd>tab</kbd>, and your editor will focus on the first setting's value (root = *true*). You can change the value, if you want, and jump to the next setting's value by hitting <kbd>tab</kbd> and so on.
+Just type `editorconfig` + <kbd>tab</kbd>, and your editor will focus on the first setting's value (indent_style = *lf*). You can change the value, if you want, and jump to the next setting's value by hitting <kbd>tab</kbd> and so on. Settings are somewhat autocompleted, and if you don't remember all possible values, simply remove the setting value to see them all as a comment.
 
 You can be in a context where `editorconfig` + <kbd>tab</kbd> trigger another snippet. In that case, simply use `Goto anywhere` (<kbd>Ctrl</kbd> + <kbd>P</kbd> on Linux/Windows or <kbd>⌘</kbd> + <kbd>P</kbd> on OSX), type `editorconfig`, select `Snippet: editorconfig` and hit <kbd>Enter</kbd>.
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,8 @@ If you can't remember all settings managed by the EditorConfig file, you'll love
 
 Just type `editorconfig` + `tab`, and your editor will focus on the first setting's value (root = *true*). You can change the value, if you want, and jump to the next setting's value by hitting `tab` and so on.
 
+You can be in a context where `editorconfig` + `tab` trigger another snippet. In that case, simply use `Goto anywhere` (`Ctrl` + `P` on Linux/Windows or `⌘` + `P` on OSX), type `editorconfig`, select `Snippet: editorconfig` and hit `Enter`.
+
 ### View active config
 
 The active config is printed in the Sublime console.

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,12 @@ trim_trailing_whitespace = false
 
 ## Tips
 
+### EditorConfig snippet
+
+If you can't remember all settings managed by the EditorConfig file, you'll love the `editorconfig` snippet.
+
+Just type `editorconfig` + `tab`, and your editor will focus on the first setting's value (root = *true*). You can change the value, if you want, and jump to the next setting's value by hitting `tab` and so on.
+
 ### View active config
 
 The active config is printed in the Sublime console.


### PR DESCRIPTION
Event if the scope of EditorConfig files is very limited, this snippet ease the creation of EditorConfig files. All parameters except `tab_size` are used, as this one has a default based on `indent_size`.