### PR TITLE
Add support for `max_line_length`

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -85,6 +85,7 @@ class EditorConfig(sublime_plugin.EventListener):
 		indent_size = config.get('indent_size')
 		trim_trailing_whitespace = config.get('trim_trailing_whitespace')
 		insert_final_newline = config.get('insert_final_newline')
+		max_line_length = config.get('max_line_length')
 		if indent_style == 'space':
 			settings.set('translate_tabs_to_spaces', True)
 		elif indent_style == 'tab':
@@ -102,5 +103,15 @@ class EditorConfig(sublime_plugin.EventListener):
 			settings.set('ensure_newline_at_eof_on_save', True)
 		elif insert_final_newline == 'false':
 			settings.set('ensure_newline_at_eof_on_save', False)
+
+		if isinstance(max_line_length, int) and max_line_length:
+			settings.set('auto_wrap', True)
+			settings.set('auto_wrap_width', max_line_length)
+		else:
+			if max_line_length == "off":
+				settings.set('auto_wrap', False)
+			else:
+				settings.erase('auto_wrap')
+			settings.erase('auto_wrap_width')
 
 		view.settings().set(self.MARKER, True)

--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -104,7 +104,12 @@ class EditorConfig(sublime_plugin.EventListener):
 		elif insert_final_newline == 'false':
 			settings.set('ensure_newline_at_eof_on_save', False)
 
-		if isinstance(max_line_length, int) and max_line_length:
+		try:
+			max_line_length = int(max_line_length)
+		except ValueError:
+			pass
+
+		if isinstance(max_line_length, int) and max_line_length > 0:
 			settings.set('auto_wrap', True)
 			settings.set('auto_wrap_width', max_line_length)
 		else:

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,11 @@ See the [EditorConfig site][] for documentation.
 - charset
 - trim_trailing_whitespace
 - insert_final_newline
+- max_line_length*
 
 Explanation of the properties can be found on the [EditorConfig site][].
 
+\* support for `max_line_length` requires the [AutoWrap](https://github.com/randy3k/AutoWrap) plugin to be installed.
 
 ## Example file
 


### PR DESCRIPTION
- Support for this feature requires the user to have installed the autowrap
  plugin https://github.com/randy3k/AutoWrap
- Property explained here https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
- Solves https://github.com/sindresorhus/editorconfig-sublime/issues/56 
