### PR TITLE
Also run on `on_load`

### DIFF
--- a/EditorConfig.py
+++ b/EditorConfig.py
@@ -39,6 +39,10 @@ def debug(msg):
 class EditorConfig(sublime_plugin.EventListener):
 	MARKER = 'editorconfig'
 
+	def on_load(self, view):
+		if not view.settings().has(self.MARKER):
+			self.init(view, 'load')
+
 	def on_activated(self, view):
 		if not view.settings().has(self.MARKER):
 			self.init(view, 'activated')
@@ -61,7 +65,7 @@ class EditorConfig(sublime_plugin.EventListener):
 			print('Error occurred while getting EditorConfig properties')
 		else:
 			if config:
-				if event == 'activated':
+				if event == 'activated' or event == 'load':
 					debug('File Path \n%s' % unexpanduser(path))
 					debug('Applied Settings \n%s' % pprint.pformat(config))
 				if event == 'pre_save':


### PR DESCRIPTION
on_activated is only called when a view gains focus. When using Ctrl+P
to look for a file the indent settings are not applied until a file is
selected. This results in the settings changing when a file is finally
picked. By applying on the load event, the settings are applied earlier
and you don't visually notice them being applied.