### PR TITLE
Make EditorConfig.sublime-syntax pyYAML parse-able

### DIFF
--- a/EditorConfig.sublime-syntax
+++ b/EditorConfig.sublime-syntax
@@ -1,4 +1,4 @@
-%YAML1.2
+%YAML 1.2
 ---
 name: EditorConfig
 file_extensions:


### PR DESCRIPTION
I have a plugin which parses all ST's syntax definition files. I accidentally found `EditorConfig.sublime-syntax` is not parse-able just because of it's first line. ST's YAML syntax won't highlight the current first line `%YAML1.2` as well but `%YAML 1.2` is fine.