### PR TITLE
Don't break `git commit --verbose`

### DIFF
--- a/editorconfig/handler.py
+++ b/editorconfig/handler.py
@@ -28,15 +28,25 @@ def get_filenames(path, filename):
         path = newpath
     return path_list
 
-def find_up(path, folder):
-    """Return true if the path contains the folder, false otherwise"""
-    new_path, basename = os.path.split(path)
+def find_up(directory, start_path):
+    """
+    Return true if ``start_path`` is child of the ``directory``,
+    false otherwise
+
+    ``start_path`` is the full path to a file or folder
+    ``directory`` is the name of the directory to find in the path
+
+    e.g.    find_up("foo", "/root/foo/bar") -> true
+            find_up("hom", "/home/foo/bar")-> false
+    """
+    new_path, base_name = os.path.split(start_path)
+    old_path=start_path
     # Stop the while when the root is reached
-    while path != new_path:
-        if basename == folder:
+    while old_path != new_path:
+        if base_name == directory:
             return True
-        path = new_path
-        new_path, basename = os.path.split(path)
+        old_path = new_path
+        new_path, base_name = os.path.split(old_path)
     return False
 
 class EditorConfigHandler(object):
@@ -137,5 +147,5 @@ class EditorConfigHandler(object):
             opts["indent_size"] = opts["tab_width"]
 
         # Set end_of_line to lf if in a .git folder
-        if find_up(self.filepath, ".git"):
+        if find_up(".git", self.filepath):
             opts["end_of_line"] = "lf"

--- a/editorconfig/handler.py
+++ b/editorconfig/handler.py
@@ -146,6 +146,6 @@ class EditorConfigHandler(object):
                 opts["indent_size"] == "tab"):
             opts["indent_size"] = opts["tab_width"]
 
-        # Set end_of_line to lf if in a .git folder
+        # Set end_of_line to lf if in a “.git” directory
         if find_up(".git", self.filepath):
             opts["end_of_line"] = "lf"

--- a/editorconfig/handler.py
+++ b/editorconfig/handler.py
@@ -125,3 +125,14 @@ class EditorConfigHandler(object):
         if ("indent_size" in opts and "tab_width" in opts and
                 opts["indent_size"] == "tab"):
             opts["indent_size"] = opts["tab_width"]
+
+        # Set end_of_line to lf if in a .git folder
+        path, filename = os.path.split(self.filepath)
+        while True:
+            newpath, filename = os.path.split(path)
+            if newpath == path:
+                break
+            path = newpath
+            if filename == ".git":
+                opts["end_of_line"] = "lf"
+                break

--- a/editorconfig/handler.py
+++ b/editorconfig/handler.py
@@ -28,6 +28,16 @@ def get_filenames(path, filename):
         path = newpath
     return path_list
 
+def find_up(path, folder):
+    """Return true if the path contains the folder, false otherwise"""
+    while True:
+        new_path, basename = os.path.split(path)
+        if basename == folder:
+            return True
+        # Stop when root reached :
+        if new_path == path:
+            return False
+        path = new_path
 
 class EditorConfigHandler(object):
 
@@ -127,12 +137,5 @@ class EditorConfigHandler(object):
             opts["indent_size"] = opts["tab_width"]
 
         # Set end_of_line to lf if in a .git folder
-        path, filename = os.path.split(self.filepath)
-        while True:
-            newpath, filename = os.path.split(path)
-            if newpath == path:
-                break
-            path = newpath
-            if filename == ".git":
-                opts["end_of_line"] = "lf"
-                break
+        if find_up(self.filepath, ".git")
+            opts["end_of_line"] = "lf"

--- a/editorconfig/handler.py
+++ b/editorconfig/handler.py
@@ -30,14 +30,14 @@ def get_filenames(path, filename):
 
 def find_up(path, folder):
     """Return true if the path contains the folder, false otherwise"""
-    while True:
-        new_path, basename = os.path.split(path)
+    new_path, basename = os.path.split(path)
+    # Stop the while when the root is reached
+    while path != new_path:
         if basename == folder:
             return True
-        # Stop when root reached :
-        if new_path == path:
-            return False
         path = new_path
+        new_path, basename = os.path.split(path)
+    return False
 
 class EditorConfigHandler(object):
 
@@ -137,5 +137,5 @@ class EditorConfigHandler(object):
             opts["indent_size"] = opts["tab_width"]
 
         # Set end_of_line to lf if in a .git folder
-        if find_up(self.filepath, ".git")
+        if find_up(self.filepath, ".git"):
             opts["end_of_line"] = "lf"


### PR DESCRIPTION
Fixes #55 by making the line endings into "lf" for all files into .git folders.

<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#55: Breaks git commit -v (git commit --verbose)](https://issuehunt.io/repos/4501025/issues/55)
---
</details>
<!-- /Issuehunt content-->