### PR TITLE
Fix typo

### DIFF
--- a/editorconfig/ini.py
+++ b/editorconfig/ini.py
@@ -145,7 +145,7 @@ class EditorConfigParser(object):
                         optname, vi, optval = mo.group('option', 'vi', 'value')
                         if ';' in optval or '#' in optval:
                             # ';' and '#' are comment delimiters only if
-                            # preceeded by a spacing character
+                            # preceded by a spacing character
                             m = re.search('(.*?) [;#]', optval)
                             if m:
                                 optval = m.group(1)


### PR DESCRIPTION
There is a small typo in editorconfig/ini.py.

Should read `preceded` rather than `preceeded`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md